### PR TITLE
Hide constructors

### DIFF
--- a/src/Math/Matrix4.elm
+++ b/src/Math/Matrix4.elm
@@ -32,31 +32,43 @@ existing matrix.
 import Native.MJS
 import Math.Vector3 exposing (Vec3)
 
-{-| 4x4 matrix type -}
-type Mat4 = Mat4
+
+{-| 4x4 matrix type
+-}
+type Mat4
+    = Mat4
+
 
 {-| Multiply a vector by a 4x4 matrix: m * v
 -}
 transform : Mat4 -> Vec3 -> Vec3
-transform = Native.MJS.v3mul4x4
+transform =
+    Native.MJS.v3mul4x4
+
 
 {-| A matrix with all 0s, except 1s on the diagonal.
 -}
 identity : Mat4
-identity = Native.MJS.m4x4identity
+identity =
+    Native.MJS.m4x4identity
+
 
 {-| Computes the inverse of any matrix. This is somewhat computationally
 intensive. If the matrix is not invertible, `Nothing` is returned.
 -}
 inverse : Mat4 -> Maybe Mat4
-inverse = Native.MJS.m4x4inverse
+inverse =
+    Native.MJS.m4x4inverse
+
 
 {-| Computes the inverse of the given matrix, assuming that the matrix is
 orthonormal. This algorithm is more efficient than general matrix inversion, and
 has no possibility of failing.
 -}
 inverseOrthonormal : Mat4 -> Mat4
-inverseOrthonormal = Native.MJS.m4x4inverseOrthonormal
+inverseOrthonormal =
+    Native.MJS.m4x4inverseOrthonormal
+
 
 {-| Creates a matrix for a projection frustum with the given parameters.
 
@@ -70,7 +82,9 @@ Parameters:
  * zfar - the far z distance of the frustum
 -}
 makeFrustum : Float -> Float -> Float -> Float -> Float -> Float -> Mat4
-makeFrustum = Native.MJS.m4x4makeFrustum
+makeFrustum =
+    Native.MJS.m4x4makeFrustum
+
 
 {-| Creates a matrix for a perspective projection with the given parameters.
 
@@ -82,7 +96,9 @@ Parameters:
  * zfar - the far z distance of the projection
 -}
 makePerspective : Float -> Float -> Float -> Float -> Mat4
-makePerspective = Native.MJS.m4x4makePerspective
+makePerspective =
+    Native.MJS.m4x4makePerspective
+
 
 {-|
 Creates a matrix for an orthogonal frustum projection with the given parameters.
@@ -97,7 +113,9 @@ Parameters:
  * zfar - the far z distance of the frustum
 -}
 makeOrtho : Float -> Float -> Float -> Float -> Float -> Float -> Mat4
-makeOrtho = Native.MJS.m4x4makeOrtho
+makeOrtho =
+    Native.MJS.m4x4makeOrtho
+
 
 {-| Creates a matrix for a 2D orthogonal frustum projection with the given
 parameters. `znear` and `zfar` are assumed to be -1 and 1, respectively.
@@ -110,75 +128,101 @@ Parameters:
  * top - the top coordinate of the frustum
 -}
 makeOrtho2D : Float -> Float -> Float -> Float -> Mat4
-makeOrtho2D = Native.MJS.m4x4makeOrtho2D
+makeOrtho2D =
+    Native.MJS.m4x4makeOrtho2D
+
 
 {-| Matrix multiplcation: a * b
 -}
 mul : Mat4 -> Mat4 -> Mat4
-mul = Native.MJS.m4x4mul
+mul =
+    Native.MJS.m4x4mul
+
 
 {-| Matrix multiplication, assuming a and b are affine: a * b
 -}
 mulAffine : Mat4 -> Mat4 -> Mat4
-mulAffine = Native.MJS.m4x4mulAffine
+mulAffine =
+    Native.MJS.m4x4mulAffine
+
 
 {-| Creates a transformation matrix for rotation in radians about the
 3-element vector axis.
 -}
 makeRotate : Float -> Vec3 -> Mat4
-makeRotate = Native.MJS.m4x4makeRotate
+makeRotate =
+    Native.MJS.m4x4makeRotate
+
 
 {-| Concatenates a rotation in radians about an axis to the given matrix.
 -}
 rotate : Float -> Vec3 -> Mat4 -> Mat4
-rotate = Native.MJS.m4x4rotate
+rotate =
+    Native.MJS.m4x4rotate
+
 
 {-| Creates a transformation matrix for scaling by 3 scalar values, one for
 each of the x, y, and z directions.
 -}
 makeScale3 : Float -> Float -> Float -> Mat4
-makeScale3 = Native.MJS.m4x4makeScale3
+makeScale3 =
+    Native.MJS.m4x4makeScale3
+
 
 {-| Creates a transformation matrix for scaling each of the x, y, and z axes by
 the amount given in the corresponding element of the 3-element vector.
 -}
 makeScale : Vec3 -> Mat4
-makeScale = Native.MJS.m4x4makeScale
+makeScale =
+    Native.MJS.m4x4makeScale
+
 
 {-| Concatenates a scaling to the given matrix.
 -}
 scale3 : Float -> Float -> Float -> Mat4 -> Mat4
-scale3 = Native.MJS.m4x4scale3
+scale3 =
+    Native.MJS.m4x4scale3
+
 
 {-| Concatenates a scaling to the given matrix.
 -}
 scale : Vec3 -> Mat4 -> Mat4
-scale = Native.MJS.m4x4scale
+scale =
+    Native.MJS.m4x4scale
+
 
 {-|
 Creates a transformation matrix for translating by 3 scalar values, one for
 each of the x, y, and z directions.
 -}
 makeTranslate3 : Float -> Float -> Float -> Mat4
-makeTranslate3 = Native.MJS.m4x4makeTranslate3
+makeTranslate3 =
+    Native.MJS.m4x4makeTranslate3
+
 
 {-| Creates a transformation matrix for translating each of the x, y, and z
 axes by the amount given in the corresponding element of the 3-element vector.
 -}
 makeTranslate : Vec3 -> Mat4
-makeTranslate = Native.MJS.m4x4makeTranslate
+makeTranslate =
+    Native.MJS.m4x4makeTranslate
+
 
 {-|
 Concatenates a translation to the given matrix.
 -}
 translate3 : Float -> Float -> Float -> Mat4 -> Mat4
-translate3 = Native.MJS.m4x4translate3
+translate3 =
+    Native.MJS.m4x4translate3
+
 
 {-|
 Concatenates a translation to the given matrix.
 -}
 translate : Vec3 -> Mat4 -> Mat4
-translate = Native.MJS.m4x4translate
+translate =
+    Native.MJS.m4x4translate
+
 
 {-|
 Creates a transformation matrix for a camera.
@@ -190,21 +234,28 @@ Parameters:
  * up - The "up" direction according to the camera
 -}
 makeLookAt : Vec3 -> Vec3 -> Vec3 -> Mat4
-makeLookAt = Native.MJS.m4x4makeLookAt
+makeLookAt =
+    Native.MJS.m4x4makeLookAt
+
 
 {-| "Flip" the matrix across the diagonal by swapping row index and column
 index.
 -}
 transpose : Mat4 -> Mat4
-transpose = Native.MJS.m4x4transpose
+transpose =
+    Native.MJS.m4x4transpose
+
 
 {-| Creates a transform from a basis consisting of 3 linearly independent vectors.
 -}
 makeBasis : Vec3 -> Vec3 -> Vec3 -> Mat4
-makeBasis = Native.MJS.m4x4makeBasis
+makeBasis =
+    Native.MJS.m4x4makeBasis
+
 
 {-| Creates a matrix from a list of elements. Returns Nothing if the length of
 the list is not exactly 16 (4x4).
 -}
 makeFromList : List Float -> Maybe Mat4
-makeFromList = Native.MJS.m4x4fromList
+makeFromList =
+    Native.MJS.m4x4fromList

--- a/src/Math/Matrix4.elm
+++ b/src/Math/Matrix4.elm
@@ -1,4 +1,31 @@
-module Math.Matrix4 exposing (..)
+module Math.Matrix4
+    exposing
+        ( Mat4
+        , identity
+        , makeFromList
+        , inverse
+        , inverseOrthonormal
+        , mul
+        , mulAffine
+        , transpose
+        , makeBasis
+        , transform
+        , makeFrustum
+        , makePerspective
+        , makeOrtho
+        , makeOrtho2D
+        , makeLookAt
+        , rotate
+        , scale
+        , scale3
+        , translate
+        , translate3
+        , makeRotate
+        , makeScale
+        , makeScale3
+        , makeTranslate
+        , makeTranslate3
+        )
 
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All matrices are immutable.

--- a/src/Math/Vector2.elm
+++ b/src/Math/Vector2.elm
@@ -1,4 +1,5 @@
 module Math.Vector2 exposing (..)
+
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
 
@@ -20,86 +21,148 @@ The set functions create a new copy of the vector, updating a single field.
 
 import Native.Math.Vector2
 
-{-| Two dimensional vector type -}
-type Vec2 = Vec2
 
-{-| Creates a new 2-element vector with the given values. -}
+{-| Two dimensional vector type
+-}
+type Vec2
+    = Vec2
+
+
+{-| Creates a new 2-element vector with the given values.
+-}
 vec2 : Float -> Float -> Vec2
-vec2 = Native.Math.Vector2.vec2
+vec2 =
+    Native.Math.Vector2.vec2
 
-{-| Extract the x component of a vector. -}
+
+{-| Extract the x component of a vector.
+-}
 getX : Vec2 -> Float
-getX = Native.Math.Vector2.getX
+getX =
+    Native.Math.Vector2.getX
 
-{-| Extract the y component of a vector. -}
+
+{-| Extract the y component of a vector.
+-}
 getY : Vec2 -> Float
-getY = Native.Math.Vector2.getY
+getY =
+    Native.Math.Vector2.getY
 
-{-| Update the x component of a vector, returning a new vector. -}
+
+{-| Update the x component of a vector, returning a new vector.
+-}
 setX : Float -> Vec2 -> Vec2
-setX = Native.Math.Vector2.setX
+setX =
+    Native.Math.Vector2.setX
 
-{-| Update the y component of a vector, returning a new vector. -}
+
+{-| Update the y component of a vector, returning a new vector.
+-}
 setY : Float -> Vec2 -> Vec2
-setY = Native.Math.Vector2.setY
+setY =
+    Native.Math.Vector2.setY
 
-{-| Convert a vector to a tuple. -}
-toTuple : Vec2 -> (Float,Float)
-toTuple = Native.Math.Vector2.toTuple
 
-{-| Convert a vector to a record. -}
-toRecord : Vec2 -> { x:Float, y:Float }
-toRecord = Native.Math.Vector2.toRecord
+{-| Convert a vector to a tuple.
+-}
+toTuple : Vec2 -> ( Float, Float )
+toTuple =
+    Native.Math.Vector2.toTuple
 
-{-| Convert a tuple to a vector. -}
-fromTuple : (Float,Float) -> Vec2
-fromTuple = Native.Math.Vector2.fromTuple
 
-{-| Convert a record to a vector. -}
-fromRecord : { x:Float, y:Float } -> Vec2
-fromRecord = Native.Math.Vector2.fromRecord
+{-| Convert a vector to a record.
+-}
+toRecord : Vec2 -> { x : Float, y : Float }
+toRecord =
+    Native.Math.Vector2.toRecord
 
-{-| Vector addition: a + b -}
+
+{-| Convert a tuple to a vector.
+-}
+fromTuple : ( Float, Float ) -> Vec2
+fromTuple =
+    Native.Math.Vector2.fromTuple
+
+
+{-| Convert a record to a vector.
+-}
+fromRecord : { x : Float, y : Float } -> Vec2
+fromRecord =
+    Native.Math.Vector2.fromRecord
+
+
+{-| Vector addition: a + b
+-}
 add : Vec2 -> Vec2 -> Vec2
-add = Native.Math.Vector2.add
+add =
+    Native.Math.Vector2.add
 
-{-| Vector subtraction: a - b -}
+
+{-| Vector subtraction: a - b
+-}
 sub : Vec2 -> Vec2 -> Vec2
-sub = Native.Math.Vector2.sub
+sub =
+    Native.Math.Vector2.sub
 
-{-| Vector negation: -a -}
+
+{-| Vector negation: -a
+-}
 negate : Vec2 -> Vec2
-negate = Native.Math.Vector2.neg
+negate =
+    Native.Math.Vector2.neg
 
-{-| The normalized direction from b to a: (a - b) / |a - b| -}
+
+{-| The normalized direction from b to a: (a - b) / |a - b|
+-}
 direction : Vec2 -> Vec2 -> Vec2
-direction = Native.Math.Vector2.direction
+direction =
+    Native.Math.Vector2.direction
 
-{-| The length of the given vector: |a| -}
+
+{-| The length of the given vector: |a|
+-}
 length : Vec2 -> Float
-length = Native.Math.Vector2.length
+length =
+    Native.Math.Vector2.length
 
-{-| The square of the length of the given vector: |a| * |a| -}
+
+{-| The square of the length of the given vector: |a| * |a|
+-}
 lengthSquared : Vec2 -> Float
-lengthSquared = Native.Math.Vector2.lengthSquared
+lengthSquared =
+    Native.Math.Vector2.lengthSquared
 
-{-| The distance between two vectors. -}
+
+{-| The distance between two vectors.
+-}
 distance : Vec2 -> Vec2 -> Float
-distance = Native.Math.Vector2.distance
+distance =
+    Native.Math.Vector2.distance
 
-{-| The square of the distance between two vectors. -}
+
+{-| The square of the distance between two vectors.
+-}
 distanceSquared : Vec2 -> Vec2 -> Float
-distanceSquared = Native.Math.Vector2.distanceSquared
+distanceSquared =
+    Native.Math.Vector2.distanceSquared
 
-{-| A unit vector with the same direction as the given vector: a / |a| -}
+
+{-| A unit vector with the same direction as the given vector: a / |a|
+-}
 normalize : Vec2 -> Vec2
-normalize = Native.Math.Vector2.normalize
+normalize =
+    Native.Math.Vector2.normalize
 
-{-| Multiply the vector by a scalar: s * v -}
+
+{-| Multiply the vector by a scalar: s * v
+-}
 scale : Float -> Vec2 -> Vec2
-scale = Native.Math.Vector2.scale
+scale =
+    Native.Math.Vector2.scale
 
-{-| The dot product of a and b -}
+
+{-| The dot product of a and b
+-}
 dot : Vec2 -> Vec2 -> Float
-dot = Native.Math.Vector2.dot
-
+dot =
+    Native.Math.Vector2.dot

--- a/src/Math/Vector2.elm
+++ b/src/Math/Vector2.elm
@@ -1,4 +1,27 @@
-module Math.Vector2 exposing (..)
+module Math.Vector2
+    exposing
+        ( Vec2
+        , vec2
+        , getX
+        , getY
+        , setX
+        , setY
+        , add
+        , sub
+        , negate
+        , scale
+        , dot
+        , normalize
+        , direction
+        , length
+        , lengthSquared
+        , distance
+        , distanceSquared
+        , toTuple
+        , fromTuple
+        , toRecord
+        , fromRecord
+        )
 
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.

--- a/src/Math/Vector3.elm
+++ b/src/Math/Vector3.elm
@@ -1,4 +1,5 @@
 module Math.Vector3 exposing (..)
+
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
 
@@ -20,110 +21,190 @@ The set functions create a new copy of the vector, updating a single field.
 
 import Native.MJS
 
-{-| Three dimensional vector type -}
-type Vec3 = Vec3
+
+{-| Three dimensional vector type
+-}
+type Vec3
+    = Vec3
+
 
 {-| Creates a new 3-element vector with the given values.
 -}
 vec3 : Float -> Float -> Float -> Vec3
-vec3 = Native.MJS.vec3
+vec3 =
+    Native.MJS.vec3
 
-{-| The unit vector &icirc; which points in the x direction: `vec3 1 0 0` -}
+
+{-| The unit vector &icirc; which points in the x direction: `vec3 1 0 0`
+-}
 i : Vec3
-i = Native.MJS.vec3 1 0 0
+i =
+    Native.MJS.vec3 1 0 0
 
-{-| The unit vector &jcirc; which points in the y direction: `vec3 0 1 0` -}
+
+{-| The unit vector &jcirc; which points in the y direction: `vec3 0 1 0`
+-}
 j : Vec3
-j = Native.MJS.vec3 0 1 0
+j =
+    Native.MJS.vec3 0 1 0
 
-{-| The unit vector k&#0770; which points in the z direction: `vec3 0 0 1` -}
+
+{-| The unit vector k&#0770; which points in the z direction: `vec3 0 0 1`
+-}
 k : Vec3
-k = Native.MJS.vec3 0 0 1
+k =
+    Native.MJS.vec3 0 0 1
 
-{-| Extract the x component of a vector. -}
+
+{-| Extract the x component of a vector.
+-}
 getX : Vec3 -> Float
-getX = Native.MJS.v3getX
+getX =
+    Native.MJS.v3getX
 
-{-| Extract the y component of a vector. -}
+
+{-| Extract the y component of a vector.
+-}
 getY : Vec3 -> Float
-getY = Native.MJS.v3getY
+getY =
+    Native.MJS.v3getY
 
-{-| Extract the z component of a vector. -}
+
+{-| Extract the z component of a vector.
+-}
 getZ : Vec3 -> Float
-getZ = Native.MJS.v3getZ
+getZ =
+    Native.MJS.v3getZ
 
-{-| Update the x component of a vector, returning a new vector. -}
+
+{-| Update the x component of a vector, returning a new vector.
+-}
 setX : Float -> Vec3 -> Vec3
-setX = Native.MJS.v3setX
+setX =
+    Native.MJS.v3setX
 
-{-| Update the y component of a vector, returning a new vector. -}
+
+{-| Update the y component of a vector, returning a new vector.
+-}
 setY : Float -> Vec3 -> Vec3
-setY = Native.MJS.v3setY
+setY =
+    Native.MJS.v3setY
 
-{-| Update the z component of a vector, returning a new vector. -}
+
+{-| Update the z component of a vector, returning a new vector.
+-}
 setZ : Float -> Vec3 -> Vec3
-setZ = Native.MJS.v3setZ
+setZ =
+    Native.MJS.v3setZ
 
-{-| Convert a vector to a tuple. -}
-toTuple : Vec3 -> (Float,Float,Float)
-toTuple = Native.MJS.toTuple3
 
-{-| Convert a vector to a record. -}
-toRecord : Vec3 -> { x:Float, y:Float, z:Float }
-toRecord = Native.MJS.toRecord3
+{-| Convert a vector to a tuple.
+-}
+toTuple : Vec3 -> ( Float, Float, Float )
+toTuple =
+    Native.MJS.toTuple3
 
-{-| Convert a tuple to a vector. -}
-fromTuple : (Float,Float,Float) -> Vec3
-fromTuple = Native.MJS.fromTuple3
 
-{-| Convert a record to a vector. -}
-fromRecord : { x:Float, y:Float, z:Float } -> Vec3
-fromRecord = Native.MJS.fromRecord3
+{-| Convert a vector to a record.
+-}
+toRecord : Vec3 -> { x : Float, y : Float, z : Float }
+toRecord =
+    Native.MJS.toRecord3
 
-{-| Vector addition: a + b -}
+
+{-| Convert a tuple to a vector.
+-}
+fromTuple : ( Float, Float, Float ) -> Vec3
+fromTuple =
+    Native.MJS.fromTuple3
+
+
+{-| Convert a record to a vector.
+-}
+fromRecord : { x : Float, y : Float, z : Float } -> Vec3
+fromRecord =
+    Native.MJS.fromRecord3
+
+
+{-| Vector addition: a + b
+-}
 add : Vec3 -> Vec3 -> Vec3
-add = Native.MJS.v3add
+add =
+    Native.MJS.v3add
 
-{-| Vector subtraction: a - b -}
+
+{-| Vector subtraction: a - b
+-}
 sub : Vec3 -> Vec3 -> Vec3
-sub = Native.MJS.v3sub
+sub =
+    Native.MJS.v3sub
 
-{-| Vector negation: -a -}
+
+{-| Vector negation: -a
+-}
 negate : Vec3 -> Vec3
-negate = Native.MJS.v3neg
+negate =
+    Native.MJS.v3neg
 
-{-| The normalized direction from b to a: (a - b) / |a - b| -}
+
+{-| The normalized direction from b to a: (a - b) / |a - b|
+-}
 direction : Vec3 -> Vec3 -> Vec3
-direction = Native.MJS.v3direction
+direction =
+    Native.MJS.v3direction
 
-{-| The length of the given vector: |a| -}
+
+{-| The length of the given vector: |a|
+-}
 length : Vec3 -> Float
-length = Native.MJS.v3length
+length =
+    Native.MJS.v3length
 
-{-| The square of the length of the given vector: |a| * |a| -}
+
+{-| The square of the length of the given vector: |a| * |a|
+-}
 lengthSquared : Vec3 -> Float
-lengthSquared = Native.MJS.v3lengthSquared
+lengthSquared =
+    Native.MJS.v3lengthSquared
 
-{-| The distance between two vectors. -}
+
+{-| The distance between two vectors.
+-}
 distance : Vec3 -> Vec3 -> Float
-distance = Native.MJS.v3distance
+distance =
+    Native.MJS.v3distance
 
-{-| The square of the distance between two vectors. -}
+
+{-| The square of the distance between two vectors.
+-}
 distanceSquared : Vec3 -> Vec3 -> Float
-distanceSquared = Native.MJS.v3distanceSquared
+distanceSquared =
+    Native.MJS.v3distanceSquared
 
-{-| A unit vector with the same direction as the given vector: a / |a| -}
+
+{-| A unit vector with the same direction as the given vector: a / |a|
+-}
 normalize : Vec3 -> Vec3
-normalize = Native.MJS.v3normalize
+normalize =
+    Native.MJS.v3normalize
 
-{-| Multiply the vector by a scalar: s * v -}
+
+{-| Multiply the vector by a scalar: s * v
+-}
 scale : Float -> Vec3 -> Vec3
-scale = Native.MJS.v3scale
+scale =
+    Native.MJS.v3scale
 
-{-| The dot product of a and b -}
+
+{-| The dot product of a and b
+-}
 dot : Vec3 -> Vec3 -> Float
-dot = Native.MJS.v3dot
+dot =
+    Native.MJS.v3dot
 
-{-| The cross product of a and b -}
+
+{-| The cross product of a and b
+-}
 cross : Vec3 -> Vec3 -> Vec3
-cross = Native.MJS.v3cross
+cross =
+    Native.MJS.v3cross

--- a/src/Math/Vector3.elm
+++ b/src/Math/Vector3.elm
@@ -1,4 +1,33 @@
-module Math.Vector3 exposing (..)
+module Math.Vector3
+    exposing
+        ( Vec3
+        , vec3
+        , i
+        , j
+        , k
+        , getX
+        , getY
+        , getZ
+        , setX
+        , setY
+        , setZ
+        , add
+        , sub
+        , negate
+        , scale
+        , dot
+        , cross
+        , normalize
+        , direction
+        , length
+        , lengthSquared
+        , distance
+        , distanceSquared
+        , toTuple
+        , fromTuple
+        , toRecord
+        , fromRecord
+        )
 
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.

--- a/src/Math/Vector4.elm
+++ b/src/Math/Vector4.elm
@@ -1,4 +1,31 @@
-module Math.Vector4 exposing (..)
+module Math.Vector4
+    exposing
+        ( Vec4
+        , vec4
+        , getX
+        , getY
+        , getZ
+        , getW
+        , setX
+        , setY
+        , setZ
+        , setW
+        , add
+        , sub
+        , negate
+        , scale
+        , dot
+        , normalize
+        , direction
+        , length
+        , lengthSquared
+        , distance
+        , distanceSquared
+        , toTuple
+        , fromTuple
+        , toRecord
+        , fromRecord
+        )
 
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.

--- a/src/Math/Vector4.elm
+++ b/src/Math/Vector4.elm
@@ -1,4 +1,5 @@
 module Math.Vector4 exposing (..)
+
 {-| A high performance linear algebra library using native JS arrays. Geared
 towards 3D graphics and use with `Graphics.WebGL`. All vectors are immutable.
 
@@ -20,102 +21,176 @@ The set functions create a new copy of the vector, updating a single field.
 
 import Native.Math.Vector4
 
-{-| Four dimensional vector type -}
-type Vec4 = Vec4
 
-{-| Creates a new 4-element vector with the given x, y, z, and w values. -}
+{-| Four dimensional vector type
+-}
+type Vec4
+    = Vec4
+
+
+{-| Creates a new 4-element vector with the given x, y, z, and w values.
+-}
 vec4 : Float -> Float -> Float -> Float -> Vec4
-vec4 = Native.Math.Vector4.vec4
+vec4 =
+    Native.Math.Vector4.vec4
 
-{-| Extract the x component of a vector. -}
+
+{-| Extract the x component of a vector.
+-}
 getX : Vec4 -> Float
-getX = Native.Math.Vector4.getX
+getX =
+    Native.Math.Vector4.getX
 
-{-| Extract the y component of a vector. -}
+
+{-| Extract the y component of a vector.
+-}
 getY : Vec4 -> Float
-getY = Native.Math.Vector4.getY
+getY =
+    Native.Math.Vector4.getY
 
-{-| Extract the z component of a vector. -}
+
+{-| Extract the z component of a vector.
+-}
 getZ : Vec4 -> Float
-getZ = Native.Math.Vector4.getZ
+getZ =
+    Native.Math.Vector4.getZ
 
-{-| Extract the w component of a vector. -}
+
+{-| Extract the w component of a vector.
+-}
 getW : Vec4 -> Float
-getW = Native.Math.Vector4.getW
+getW =
+    Native.Math.Vector4.getW
 
-{-| Update the x component of a vector, returning a new vector. -}
+
+{-| Update the x component of a vector, returning a new vector.
+-}
 setX : Float -> Vec4 -> Vec4
-setX = Native.Math.Vector4.setX
+setX =
+    Native.Math.Vector4.setX
 
-{-| Update the y component of a vector, returning a new vector. -}
+
+{-| Update the y component of a vector, returning a new vector.
+-}
 setY : Float -> Vec4 -> Vec4
-setY = Native.Math.Vector4.setY
+setY =
+    Native.Math.Vector4.setY
 
-{-| Update the z component of a vector, returning a new vector. -}
+
+{-| Update the z component of a vector, returning a new vector.
+-}
 setZ : Float -> Vec4 -> Vec4
-setZ = Native.Math.Vector4.setZ
+setZ =
+    Native.Math.Vector4.setZ
 
-{-| Update the w component of a vector, returning a new vector. -}
+
+{-| Update the w component of a vector, returning a new vector.
+-}
 setW : Float -> Vec4 -> Vec4
-setW = Native.Math.Vector4.setW
+setW =
+    Native.Math.Vector4.setW
 
-{-| Convert a vector to a tuple. -}
-toTuple : Vec4 -> (Float,Float,Float,Float)
-toTuple = Native.Math.Vector4.toTuple
 
-{-| Convert a vector to a record. -}
-toRecord : Vec4 -> { x:Float, y:Float, z:Float, w:Float }
-toRecord = Native.Math.Vector4.toRecord
+{-| Convert a vector to a tuple.
+-}
+toTuple : Vec4 -> ( Float, Float, Float, Float )
+toTuple =
+    Native.Math.Vector4.toTuple
 
-{-| Convert a tuple to a vector. -}
-fromTuple : (Float,Float,Float,Float) -> Vec4
-fromTuple = Native.Math.Vector4.fromTuple
 
-{-| Convert a record to a vector. -}
-fromRecord : { x:Float, y:Float, z:Float, w:Float } -> Vec4
-fromRecord = Native.Math.Vector4.fromRecord
+{-| Convert a vector to a record.
+-}
+toRecord : Vec4 -> { x : Float, y : Float, z : Float, w : Float }
+toRecord =
+    Native.Math.Vector4.toRecord
 
-{-| Vector addition: a + b -}
+
+{-| Convert a tuple to a vector.
+-}
+fromTuple : ( Float, Float, Float, Float ) -> Vec4
+fromTuple =
+    Native.Math.Vector4.fromTuple
+
+
+{-| Convert a record to a vector.
+-}
+fromRecord : { x : Float, y : Float, z : Float, w : Float } -> Vec4
+fromRecord =
+    Native.Math.Vector4.fromRecord
+
+
+{-| Vector addition: a + b
+-}
 add : Vec4 -> Vec4 -> Vec4
-add = Native.Math.Vector4.add
+add =
+    Native.Math.Vector4.add
 
-{-| Vector subtraction: a - b -}
+
+{-| Vector subtraction: a - b
+-}
 sub : Vec4 -> Vec4 -> Vec4
-sub = Native.Math.Vector4.sub
+sub =
+    Native.Math.Vector4.sub
 
-{-| Vector negation: -a -}
+
+{-| Vector negation: -a
+-}
 negate : Vec4 -> Vec4
-negate = Native.Math.Vector4.neg
+negate =
+    Native.Math.Vector4.neg
 
-{-| The normalized direction from b to a: (a - b) / |a - b| -}
+
+{-| The normalized direction from b to a: (a - b) / |a - b|
+-}
 direction : Vec4 -> Vec4 -> Vec4
-direction = Native.Math.Vector4.direction
+direction =
+    Native.Math.Vector4.direction
 
-{-| The length of the given vector: |a| -}
+
+{-| The length of the given vector: |a|
+-}
 length : Vec4 -> Float
-length = Native.Math.Vector4.length
+length =
+    Native.Math.Vector4.length
 
-{-| The square of the length of the given vector: |a| * |a| -}
+
+{-| The square of the length of the given vector: |a| * |a|
+-}
 lengthSquared : Vec4 -> Float
-lengthSquared = Native.Math.Vector4.lengthSquared
+lengthSquared =
+    Native.Math.Vector4.lengthSquared
 
-{-| The distance between two vectors. -}
+
+{-| The distance between two vectors.
+-}
 distance : Vec4 -> Vec4 -> Float
-distance = Native.Math.Vector4.distance
+distance =
+    Native.Math.Vector4.distance
 
-{-| The square of the distance between two vectors. -}
+
+{-| The square of the distance between two vectors.
+-}
 distanceSquared : Vec4 -> Vec4 -> Float
-distanceSquared = Native.Math.Vector4.distanceSquared
+distanceSquared =
+    Native.Math.Vector4.distanceSquared
 
-{-| A unit vector with the same direction as the given vector: a / |a| -}
+
+{-| A unit vector with the same direction as the given vector: a / |a|
+-}
 normalize : Vec4 -> Vec4
-normalize = Native.Math.Vector4.normalize
+normalize =
+    Native.Math.Vector4.normalize
 
-{-| Multiply the vector by a scalar: s * v -}
+
+{-| Multiply the vector by a scalar: s * v
+-}
 scale : Float -> Vec4 -> Vec4
-scale = Native.Math.Vector4.scale
+scale =
+    Native.Math.Vector4.scale
 
-{-| The dot product of a and b -}
+
+{-| The dot product of a and b
+-}
 dot : Vec4 -> Vec4 -> Float
-dot = Native.Math.Vector4.dot
-
+dot =
+    Native.Math.Vector4.dot


### PR DESCRIPTION
This change hides the type constructors (`Vec2`, `Vec3`, `Vec4`, `Mat4`) as suggested by @eeue56.

The first commit is the result of running elm-format over all Elm source, and only that.

The second commit restricts the modules to expose all but those type constructors.

This change, if merged and published, will be a major change to the package version.