### PR TITLE
Convert Mat4 to and from a record

### DIFF
--- a/src/Math/Matrix4.elm
+++ b/src/Math/Matrix4.elm
@@ -2,6 +2,8 @@ module Math.Matrix4
     exposing
         ( Mat4
         , identity
+        , fromRecord
+        , toRecord
         , makeFromList
         , inverse
         , inverseOrthonormal
@@ -53,6 +55,10 @@ existing matrix.
 # Create Transformations
 
 @docs makeRotate, makeScale, makeScale3, makeTranslate, makeTranslate3
+
+# Conversions
+
+@docs toRecord, fromRecord
 
 -}
 
@@ -286,3 +292,17 @@ the list is not exactly 16 (4x4).
 makeFromList : List Float -> Maybe Mat4
 makeFromList =
     Native.MJS.m4x4fromList
+
+
+{-| Convert a matrix to a record.
+-}
+toRecord : Mat4 -> { m11 : Float, m21 : Float, m31 : Float, m41 : Float, m12 : Float, m22 : Float, m32 : Float, m42 : Float, m13 : Float, m23 : Float, m33 : Float, m43 : Float, m14 : Float, m24 : Float, m34 : Float, m44 : Float }
+toRecord =
+    Native.MJS.m4x4toRecord
+
+
+{-| Convert a record to a matrix.
+-}
+fromRecord : { m11 : Float, m21 : Float, m31 : Float, m41 : Float, m12 : Float, m22 : Float, m32 : Float, m42 : Float, m13 : Float, m23 : Float, m33 : Float, m43 : Float, m14 : Float, m24 : Float, m34 : Float, m44 : Float } -> Mat4
+fromRecord =
+    Native.MJS.m4x4fromRecord

--- a/src/Native/MJS.js
+++ b/src/Native/MJS.js
@@ -582,6 +582,50 @@ var _elm_community$linear_algebra$Native_MJS = function() {
     }
 
     /*
+     * Function: M4x4.fromRecord
+     *
+     * Creates a new 4x4 matrix from the given record.
+     *
+     * Parameters:
+     *
+     * A record with m11..m44 attributes - the 16 elements of the new matrix
+     *
+     * Returns:
+     *
+     * A new matrix filled with the values from the given record.
+     */
+    M4x4.fromRecord = function(r) {
+        return new MJS_FLOAT_ARRAY_TYPE([
+            r.m11, r.m21, r.m31, r.m41,
+            r.m12, r.m22, r.m32, r.m42,
+            r.m13, r.m23, r.m33, r.m43,
+            r.m14, r.m24, r.m34, r.m44
+        ]);
+    }
+
+    /*
+     * Function: M4x4.toRecord
+     *
+     * Creates a record from the given matrix
+     *
+     * Parameters:
+     *
+     * A 4x4 matrix
+     *
+     * Returns:
+     *
+     * A new record with m11..m44 attributes - the 16 elements of the given matrix
+     */
+    M4x4.toRecord = function(m) {
+        return {
+            m11: m[0], m21: m[1], m31: m[2], m41: m[3],
+            m12: m[4], m22: m[5], m32: m[6], m42: m[7],
+            m13: m[8], m23: m[9], m33: m[10], m43: m[11],
+            m14: m[12], m24: m[13], m34: m[14], m44: m[15]
+        };
+    }
+
+    /*
      * Function: M4x4.topLeft3x3
      *
      * Return the top left 3x3 matrix from the given 4x4 matrix m.
@@ -1847,6 +1891,8 @@ var _elm_community$linear_algebra$Native_MJS = function() {
         v3cross: F2(V3.cross),
         v3mul4x4: F2(V3.mul4x4),
         m4x4fromList: M4x4.fromList,
+        m4x4fromRecord: M4x4.fromRecord,
+        m4x4toRecord: M4x4.toRecord,
         m4x4identity: M4x4.identity,
         m4x4topLeft3x3: M4x4.topLeft3x3,
         m4x4inverse: M4x4.inverse,

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -87,6 +87,15 @@ suite =
                 , test "makeFromList should return Nothing for too long list of elements" <|
                     \_ ->
                         M4.makeFromList ([ 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1 ]) |> Expect.equal Nothing
+                , test "fromRecord should be able to create the identity matrix" <|
+                    \_ ->
+                        M4.fromRecord { m11 = 1, m21 = 0, m31 = 0, m41 = 0, m12 = 0, m22 = 1, m32 = 0, m42 = 0, m13 = 0, m23 = 0, m33 = 1, m43 = 0, m14 = 0, m24 = 0, m34 = 0, m44 = 1 } |> Expect.equal M4.identity
+                , test "toRecord should convert the identity matrix" <|
+                    \_ ->
+                        { m11 = 1, m21 = 0, m31 = 0, m41 = 0, m12 = 0, m22 = 1, m32 = 0, m42 = 0, m13 = 0, m23 = 0, m33 = 1, m43 = 0, m14 = 0, m24 = 0, m34 = 0, m44 = 1 } |> Expect.equal (M4.toRecord M4.identity)
+                , fuzz fuzz4x4 "fromRecord should be the opposite of toRecord" <|
+                    \record4x4 ->
+                        M4.toRecord (M4.fromRecord record4x4) |> Expect.equal record4x4
                 , test "matrix should not lose precision" <|
                     \_ ->
                         let
@@ -112,3 +121,43 @@ suite =
                 ]
             ]
         ]
+
+
+fuzz4x4 : Fuzz.Fuzzer { m11 : Float, m21 : Float, m31 : Float, m41 : Float, m12 : Float, m22 : Float, m32 : Float, m42 : Float, m13 : Float, m23 : Float, m33 : Float, m43 : Float, m14 : Float, m24 : Float, m34 : Float, m44 : Float }
+fuzz4x4 =
+    Fuzz.map
+        (\m11 m21 m31 m41 m12 m22 m32 m42 m13 m23 m33 m43 m14 m24 m34 m44 ->
+            { m11 = m11
+            , m21 = m21
+            , m31 = m31
+            , m41 = m41
+            , m12 = m12
+            , m22 = m22
+            , m32 = m32
+            , m42 = m42
+            , m13 = m13
+            , m23 = m23
+            , m33 = m33
+            , m43 = m43
+            , m14 = m14
+            , m24 = m24
+            , m34 = m34
+            , m44 = m44
+            }
+        )
+        Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float
+        |> Fuzz.andMap Fuzz.float


### PR DESCRIPTION
This implements `Mat4` conversion to and from a record. 

Closes #11.