### PR TITLE
Vec4 setters, fixes issue:14

### DIFF
--- a/src/Native/Math/Vector4.js
+++ b/src/Native/Math/Vector4.js
@@ -61,16 +61,16 @@ var _elm_community$linear_algebra$Native_Math_Vector4 = function() {
         return a[3];
     }
     V4.setX = function V4_setX(x, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(x, a[1], a[2], a[3]);
+        return new MJS_FLOAT_ARRAY_TYPE([x, a[1], a[2], a[3]]);
     }
     V4.setY = function V4_setY(y, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(a[0], y, a[2], a[3]);
+        return new MJS_FLOAT_ARRAY_TYPE([a[0], y, a[2], a[3]]);
     }
     V4.setZ = function V4_setZ(z, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(a[0], a[1], z, a[3]);
+        return new MJS_FLOAT_ARRAY_TYPE([a[0], a[1], z, a[3]]);
     }
     V4.setW = function V4_setW(w, a) {
-        return new MJS_FLOAT_ARRAY_TYPE(a[0], a[1], a[2], w);
+        return new MJS_FLOAT_ARRAY_TYPE([a[0], a[1], a[2], w]);
     }
 
     V4.toTuple = function V4_toTuple(a) {

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -5,6 +5,7 @@ import Fuzz
 import Expect
 import Math.Vector2 as V2
 import Math.Vector3 as V3
+import Math.Vector4 as V4
 import Math.Matrix4 as M4
 
 
@@ -27,6 +28,33 @@ suite =
                     Expect.equal
                         (V2.vec2 3 6)
                         (V2.vec2 3 4 |> V2.setY 6)
+            ]
+        , describe "Vector4 module"
+            [ test "vec4" <|
+                \() ->
+                    Expect.equal
+                        (V4.vec4 1 2 3 4)
+                        (V4.vec4 1 2 3 4)
+            , test "setX" <|
+                \() ->
+                    Expect.equal
+                        (V4.vec4 5 2 3 4)
+                        (V4.vec4 1 2 3 4 |> V4.setX 5)
+            , test "setY" <|
+                \() ->
+                    Expect.equal
+                        (V4.vec4 1 6 3 4)
+                        (V4.vec4 1 2 3 4 |> V4.setY 6)
+            , test "setZ" <|
+                \() ->
+                    Expect.equal
+                        (V4.vec4 1 2 7 4)
+                        (V4.vec4 1 2 3 4 |> V4.setZ 7)
+            , test "setW" <|
+                \() ->
+                    Expect.equal
+                        (V4.vec4 1 2 3 8)
+                        (V4.vec4 1 2 3 4 |> V4.setW 8)
             ]
         , describe "Matrix4 module"
             [ describe "inverse"


### PR DESCRIPTION
This branch fixes the vector4 setters, as explained in issue #14.

Passing positional args to MJS_FLOAT_ARRAY_TYPE() interprets the first arg as the length. The fix is to pass a single list argument instead.